### PR TITLE
fix: another valid output for F1-600

### DIFF
--- a/src/drstorage/models/base.py
+++ b/src/drstorage/models/base.py
@@ -8,6 +8,7 @@ from construct import (
     Computed,
     Checksum,
     Terminated,
+    OneOf,
 )
 
 
@@ -19,7 +20,7 @@ def DrStorageFactory(model_number=None):
             Struct(
                 Const(b"\xab\xab"),
                 "raw_humidity" / Int16ub,
-                Const(b"\x12"),
+                OneOf(Bytes(1), [b"\x12", b"\x10"]),
                 "raw_temperature" / Int16ub,
                 Const(b"\x12"),
                 "raw_humidity_precise" / Int16ub,

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -2,20 +2,31 @@ import drstorage
 import pytest
 
 testdata = {
-    "F1_600": {
-        "data": bytearray.fromhex(
-            "abab00471200c5120901000000000000000a10025810000000000000140d0a"
-        ),
-        "temperature": 19.7,
-        "humidity": 7.1,
-    },
-    "X2M_157": {
-        "data": bytearray.fromhex(
-            "abab004d1200cf120a3b000000000000000a10009d10000000000000a20d0a"
-        ),
-        "temperature": 20.7,
-        "humidity": 7.7,
-    },
+    "F1_600": [
+        {
+            "data": bytearray.fromhex(
+                "abab00471200c5120901000000000000000a10025810000000000000140d0a"
+            ),
+            "temperature": 19.7,
+            "humidity": 7.1,
+        },
+        {
+            "data": bytearray.fromhex(
+                "abab000b1000ce12093a000000000000000a10025810000000000000180d0a"
+            ),
+            "temperature": 20.6,
+            "humidity": 1.1,
+        },
+    ],
+    "X2M_157": [
+        {
+            "data": bytearray.fromhex(
+                "abab004d1200cf120a3b000000000000000a10009d10000000000000a20d0a"
+            ),
+            "temperature": 20.7,
+            "humidity": 7.7,
+        }
+    ],
 }
 
 
@@ -24,25 +35,28 @@ def data():
     return testdata
 
 
-@pytest.mark.parametrize("data", testdata.values(), ids=testdata.keys())
-def test_parse(data):
-    result = drstorage.models.generic.parse(data["data"])
-    assert result
-    assert result.temperature == data["temperature"]
-    assert result.humidity == data["humidity"]
+@pytest.mark.parametrize("dataset", testdata.values(), ids=testdata.keys())
+def test_parse(dataset):
+    for data in dataset:
+        result = drstorage.models.generic.parse(data["data"])
+        assert result
+        assert result.temperature == data["temperature"]
+        assert result.humidity == data["humidity"]
 
 
 def test_parse_F1_600():
-    data = testdata["F1_600"]
-    result = drstorage.models.F1_600.parse(data["data"])
-    assert result
-    assert result.temperature == data["temperature"]
-    assert result.humidity == data["humidity"]
+    dataset = testdata["F1_600"]
+    for data in dataset:
+        result = drstorage.models.F1_600.parse(data["data"])
+        assert result
+        assert result.temperature == data["temperature"]
+        assert result.humidity == data["humidity"]
 
 
 def test_parse_X2M_157(data):
-    data = testdata["X2M_157"]
-    result = drstorage.models.X2M_157.parse(data["data"])
-    assert result
-    assert result.temperature == data["temperature"]
-    assert result.humidity == data["humidity"]
+    dataset = testdata["X2M_157"]
+    for data in dataset:
+        result = drstorage.models.X2M_157.parse(data["data"])
+        assert result
+        assert result.temperature == data["temperature"]
+        assert result.humidity == data["humidity"]


### PR DESCRIPTION
- allow for multiple test datasets and add a new thing to test
- get test passing for new output we've observed

It seems that `0x10` is a valid delimiter for the first portion before the raw temperature field, so allow for that option. Loosen only as much as we need it to while keeping it strict.
