### PR TITLE
ci: Drop use of pip '2020-resolver' preview

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip install -q --no-cache-dir --use-feature=2020-resolver -e .[complete]
+        python -m pip install -q -e .[complete]
         python -m pip list
     - name: Check MANIFEST
       if: matrix.python-version == 3.8 && matrix.os == 'ubuntu-latest'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip install --upgrade -q --no-cache-dir --use-feature=2020-resolver -e .[lint]
+        python -m pip install --upgrade -q -e .[lint]
         python -m pip list
     - name: Lint with flake8
       run: |


### PR DESCRIPTION
The 2020-resolver is now the default for pip

Needed for PR #65